### PR TITLE
Update “Donate” page link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="py-3 footer">
   <div class="padded-content">
     <p><a href="https://github.com/Open-Uptown/codeofconduct/blob/master/README.md" target="_blank">Code of Conduct</a></p>
-    <p><a href="https://secure.codeforamerica.org/page/contribute/default?source_codes=Brigade-page&brigade=Open%20Uptown" target="_blank">Donate</a></p>
+    <p><a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Chicago&utm_source=CodeforChicago%20site" target="_blank">Donate</a></p>
     <p class="text-center">Copyright 2019 Code for Chicago</p>
     <p class="text-center">Code for America Labs, Inc. is a non-partisan, non-political 501(c)(3) charitable organization</p>
 


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ