### PR TITLE
Header hero alignment

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -1,11 +1,13 @@
-<div class="header-line-container">
-  <div class="header-contents">
-    <div class="header-text">
-      <h4 class="hero-header-subheading">A code for America Brigade</h4>
-      <h1 class="hero-header-heading--desktop">Making community services work in a digital age</h1>
-      <h1 class="hero-header-heading--mobile">Are you a Chicagoland nonprofit that needs some tech help?</h1>
-      <p class="hero-header-paragraph">We forge partnerships between neighbors who use technology to improve interactions with, and access to, public services.</p>
+<div class="header-background-container">
+  <div class="header-line-container">
+    <div class="header-contents">
+      <div class="header-text">
+        <h4 class="hero-header-subheading">A code for America Brigade</h4>
+        <h1 class="hero-header-heading--desktop">Making community services work in a digital age</h1>
+        <h1 class="hero-header-heading--mobile">Are you a Chicagoland nonprofit that needs some tech help?</h1>
+        <p class="hero-header-paragraph">We forge partnerships between neighbors who use technology to improve interactions with, and access to, public services.</p>
+      </div>
     </div>
+    <div class="hero-header-image"></div>
   </div>
-  <div class="hero-header-image"></div>
 </div>

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -129,6 +129,7 @@ h1,h2,h3 {
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
+    padding-left: 0;
   }
 }
 

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -131,6 +131,14 @@ h1,h2,h3 {
     justify-content: flex-end;
     padding-left: 0;
   }
+  @media (min-width: 1440px) {
+    max-width: 1440px;
+    margin: 0 auto;
+  }
+}
+
+.header-background-container {
+  background: $cfa-red;
 }
 
 .header-contents {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -55,6 +55,7 @@ h1,h2,h3 {
 .social-container {
   display: block;
   align-self: center;
+  margin-right: 24px; 
 }
 
 .logo-container {
@@ -68,17 +69,21 @@ h1,h2,h3 {
   height: auto;
 }
 
-
 .social-logo {
   display: inline;
-  margin-left: 16px;
-  vertical-align: center; 
+  margin-left: 1rem;
+  justify-self: center; 
 }
 
 .social-img {
-  height: 16px;
-  width: 16px;
+  height: 1.5rem;
+  width: 1.5rem;
   z-index: 1;
+}
+
+.donate-container {
+  align-self: center; 
+  vertical-align: center;
 }
 
 @media (max-width: 651px) {
@@ -100,26 +105,17 @@ h1,h2,h3 {
 
 @media (min-width: 750px) {
   .navbar {
-    margin: 24px 0;
-    height: 47px;
+    margin: 1.5rem 0;
   }
   .logo-container {
     width: 120px;
-    min-height: 60px;
-  }
-  .social-container {
-    margin-left: 16px;
-  }
-  .social-img {
-    height: 24px;
-    width: 24px;
+    min-height: 47px;
   }
 }
 
 @media (min-width: 1440px) {
   .navbar {
     margin: 24px auto;
-    height: 47px;
     max-width: 1440px;
   }
 }
@@ -128,8 +124,7 @@ h1,h2,h3 {
   display: flex;
   background-color: $cfa-red;
   align-items: center;
-  justify-content: center;
-
+  padding-left: 6rem;
   @media (max-width: 1058px) {
     flex-direction: column;
     align-items: center;
@@ -202,7 +197,6 @@ h1,h2,h3 {
 .header-text {
   max-width: 30.75rem;
   margin-right: 3rem;
-  padding-left: 6rem;
 
   @media (max-width: 1058px) {
     width: 100%;
@@ -595,7 +589,6 @@ h1,h2,h3 {
   padding-bottom: 0.75rem;
   padding-left: 1rem;
   padding-right: 1rem;
-  margin-left: 1rem;
   text-align: center;
   text-decoration: none;
   border-radius: 2px;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -40,8 +40,12 @@ h1,h2,h3 {
   justify-content: space-between;
   position: relative;
   width: 100%;
-  margin: 16px 0;
+  padding: 0 6rem;
+  margin: 1.5rem 0;
   height: 47px;
+  @media (max-width: 768px) {
+    padding: 0 3rem;
+  }
 }
 
 .navbar a {
@@ -50,28 +54,25 @@ h1,h2,h3 {
 
 .social-container {
   display: block;
-  align-items: center;
+  align-self: center;
 }
 
 .logo-container {
   display: inline;
   overflow: hidden;
-  height: inherit;
-}
+  height: 100%;
+} 
 
 .brigade-logo {
   max-width: 120px;
+  height: auto;
 }
 
-@media (max-width: 812px) {
-  .brigade-logo {
-    height: 100%;
-  }
-}
 
 .social-logo {
   display: inline;
   margin-left: 16px;
+  vertical-align: center; 
 }
 
 .social-img {
@@ -80,10 +81,12 @@ h1,h2,h3 {
   z-index: 1;
 }
 
-@media (min-width: 651px) {
+@media (max-width: 651px) {
   .navbar {
     margin: 16px 0;
-    height: 32px;
+  }
+  .social-container {
+    display: none;
   }
 }
 
@@ -595,7 +598,6 @@ h1,h2,h3 {
   margin-left: 1rem;
   text-align: center;
   text-decoration: none;
-  margin-top: 2rem !important;
   border-radius: 2px;
   a {
     color: white;


### PR DESCRIPTION
Adjusted spacing for the header's social media icons and padding margins for the whole navbar. Also adjusted alignment to the hero text content. At 651px, hide social-container and its contents. 

Note that there are other changes I am working on to the header per [this ticket](https://trello.com/c/kr0CIViw), but this pull request is for [Header Padding and Hero Alignment](https://trello.com/c/3xjXsJkt). 

![navbar 768 651](https://user-images.githubusercontent.com/65411628/108236708-d14d9180-710c-11eb-8ced-aaf17831991e.png)
![navbar 1440 768](https://user-images.githubusercontent.com/65411628/108236712-d1e62800-710c-11eb-8000-8d18d65003b3.png)
![social media icons](https://user-images.githubusercontent.com/65411628/108236713-d1e62800-710c-11eb-8770-7cd4619f13d6.png)


