### PR TITLE
header-breakpoints

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -70,7 +70,7 @@ h1,h2,h3 {
 } 
 
 .brigade-logo {
-  max-width: 120px;
+  width: 120px;
   height: auto;
 }
 
@@ -89,6 +89,12 @@ h1,h2,h3 {
 .donate-container {
   align-self: center; 
   vertical-align: center;
+}
+
+@media (max-width: 360px) {
+  .navbar {
+    padding: 0 24px; 
+  }
 }
 
 @media (max-width: 651px) {


### PR DESCRIPTION
change brigade-logo to fixed width rather than max-width to prevent disappearing act and add 360px breakpoint media query for header padding

this should bring the header/navbar into alignment with the figma breakpoints while maintaining the header-hero alignment. 