### PR TITLE
add forward slash to img src in footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="padded-content">
     <div class="row align-items-center">
       <div class="col-12 col-md-3 footer-icon">
-        <img src="../images/cfc_logo_short.svg" alt="Code for Chicago Logo Icon"/>
+        <img src="/../images/cfc_logo_short.svg" alt="Code for Chicago Logo Icon"/>
       </div>
       <div class="col-12 col-md-9">
 	<p><a href="https://codeforamerica.org/" target="blank">Code for America Labs, Inc.</a> is a non-partisan, non-political 501(c)(3) charitable organization</p>


### PR DESCRIPTION
ticket[https://trello.com/c/PFKc6PYt/123-footer-breaks-on-any-blog-post-page](url)

Added a forward slash to make the footer image display on the blog post pages. Changed src="../images/cfc_logo_short.svg" to src="/../images/cfc_logo_short.svg".