### PR TITLE
fix footer icon padding

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="pb-3 footer">
+<footer class="py-3 footer">
   <div class="padded-content">
     <div class="row align-items-center">
       <div class="col-12 col-md-3 footer-icon">


### PR DESCRIPTION
[ticket](https://trello.com/c/QIkh5QZn/122-footer-icon-is-not-correctly-padded)

Addressed the footer's missing top padding by changing the footer element's bootstrap class from pb-3 to py-3. The entire footer should probably be redone without all of the bootstrap classes, but I figured that would be another ticket. In pagination.html, there is a bootstrap mb-3 class that made the footer appear to be correctly spaced on pages where the pagination.html is above footer.html, like the join page. 