### PR TITLE
Adjust Contact Us form field

### DIFF
--- a/scss/custom/_reset.scss
+++ b/scss/custom/_reset.scss
@@ -318,6 +318,10 @@ input[type="month"] {
   // and https://github.com/twbs/bootstrap/issues/11266
   -webkit-appearance: listbox;
 }
+input[type="email"] {
+  -moz-appearance: none;
+}
+
 
 textarea {
   overflow: auto; // Remove the default vertical scrollbar in IE.

--- a/scss/custom/_reset.scss
+++ b/scss/custom/_reset.scss
@@ -318,10 +318,12 @@ input[type="month"] {
   // and https://github.com/twbs/bootstrap/issues/11266
   -webkit-appearance: listbox;
 }
-input[type="email"] {
-  -moz-appearance: none;
-}
 
+@-moz-document url-prefix() { 
+  input[type="email"] {
+    border: 0;
+  }
+}
 
 textarea {
   overflow: auto; // Remove the default vertical scrollbar in IE.


### PR DESCRIPTION
[ticket](https://trello.com/c/sA1T07dK/127-home-portfolio-pages-adjust-contact-us-form-fields)

The "Contact Us" email input field has some padding and border issues in the firefox browser causing the width to not be 100%. I added a reset for input type=email that targets firefox.

