### PR TITLE
Remove gray background around how to join section

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -2179,7 +2179,7 @@ p.cardText {
 }
 
 .how-to-join-container {
-  background-color: $off-white;
+  background-color: $white;
 }
 
 .volunteerContent {


### PR DESCRIPTION
This PR addresses [this Trello ticket](https://trello.com/c/hcQxmKQE/295-cfc-website-fix-join-page-style-bugs).