### PR TITLE
Fix iconTile width to render 2 rows on mobile

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -1050,6 +1050,7 @@ hr {
   @media (max-width: 767px) {
     padding: 0;
     .iconTile {
+      width: 50%;
       margin-top: 24px;
       margin-bottom: 24px;
     }


### PR DESCRIPTION
Changed width from 100% to 50% for `iconTile` containers to render 2 icons per row instead of 1