### PR TITLE
Update case study h1 font size to 48px/3rem to match other h1 styling

### DIFF
--- a/scss/custom/includes/_portfolio.scss
+++ b/scss/custom/includes/_portfolio.scss
@@ -6,6 +6,9 @@
 
   .portfolio-upper {
     width: 100%;
+    h1 {
+      font-size: 3rem !important;
+    }
 
     .portfolio-tags {
       display: inline-block;


### PR DESCRIPTION
This PR addresses this [Trello ticket](https://trello.com/c/Audcbaio/368-update-case-study-h1-styling).