### PR TITLE
Center align icons and links within mobile nav for breakpoints higher than 360px

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -174,6 +174,15 @@ hr {
   }
 }
 
+.internal-links-mobile {
+  text-align: center;
+
+  @media (max-width: 360px) {
+    text-align: left;
+    margin-left: 1rem;
+  }
+}
+
 .hideable-int-link {
   // menu goes mobile
   @media (max-width: $breakpoint-lg) {
@@ -228,7 +237,7 @@ hr {
 
 .external-links-mobile {
   display: flex;
-  justify-content: left;
+  justify-content: center;
 
   .social-logo:first-child {
     margin-left: 0;


### PR DESCRIPTION
This PR addresses this [Trello ticket](https://trello.com/c/zAIRhujA/374-cfc-website-center-align-icons-within-mobile-nav).